### PR TITLE
[package.json] Limit react / react-dom to peerDependencies & devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
   },
   "homepage": "https://github.com/fdaciuk/react-trianglify#readme",
   "dependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
     "trianglify": "^1.0.1"
   },
   "peerDependencies": {
@@ -54,6 +52,8 @@
     "babel-preset-stage-0": "^6.16.0",
     "canvas": "^1.6.2",
     "cross-env": "^3.1.3",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
     "snazzy": "^5.0.0",
     "standard": "^8.5.0",
     "standard-loader": "^5.0.0",


### PR DESCRIPTION
The context is in [this comment](https://github.com/fdaciuk/react-trianglify/issues/1#issuecomment-284810944).

> @fdaciuk Hey! I should've been more descriptive in the original write-up. I think react and react-dom should be in `devDependencies` and `peerDependencies`, but not `dependencies`. More info in the first comment here about the differences: http://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies

> By putting react/react-dom into `devDependencies`, you'll get the modules installed when developing the package; and by placing react/react-dom into `peerDependencies`, you're nudging users to make sure their main project (that consumes the react-trianglify project) has an acceptable version of react/react-dom specified, but you are not explicitly installing it for them (as `dependencies` would do).

> Looking at other folks who Release react modules, that seems to be the common setup. I look at the [package.json](https://github.com/callemall/material-ui/blob/master/package.json#L44-L106) file for material-ui and confirmed that react/react-dom are only included in `peerDependencies` and `devDependencies`.