### PR TITLE
allow node versions newer than 11.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "webpack-cli": "3.3.9"
   },
   "engines": {
-    "node": "=11.6.0"
+    "node": ">=11.6.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Regarding this issue (https://github.com/fdaciuk/react-trianglify/issues/11)