### PR TITLE
fix: use importmap for external dep in Storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import { mergeConfig, UserConfig } from "vite"
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -14,34 +13,17 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
-  core: {
-    builder: {
-      name: "@storybook/builder-vite",
-      options: {
-        viteConfigPath: "./vite.config.ts",
-      },
-    },
-  },
   previewHead: (head) => `
     <script src="https://unpkg.com/trianglify@^4/dist/trianglify.bundle.js"></script>
-    <script>console.log("trianglify:", trianglify)</script>
+    <script type="importmap">
+      {
+        "imports": {
+          "trianglify": "https://unpkg.com/trianglify@^4/dist/trianglify.bundle.js"
+        }
+      }
+    </script>
     ${head}
   `,
-  // viteFinal: (config) => {
-  //   return mergeConfig(config, {
-  //     build: {
-  //       rollupOptions: {
-  //         external: ["trianglify"],
-  //         output: {
-  //           format: "umd",
-  //           globals: {
-  //             trianglify: "trianglify",
-  //           },
-  //         },
-  //       },
-  //     },
-  //   } satisfies UserConfig)
-  // },
   docs: {
     autodocs: "tag",
   },

--- a/src/trianglify.jsx
+++ b/src/trianglify.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useEffect, useState } from 'react'
-import trianglify from 'trianglify'
+import 'trianglify'
 
 export function Trianglify({
   output = 'canvas',
@@ -34,7 +34,7 @@ export function Trianglify({
   )
 
   useEffect(() => {
-    const pattern = trianglify({
+    const pattern = window.trianglify({
       width,
       height,
       ...props

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,16 +5,4 @@ import tsConfigPaths from 'vite-tsconfig-paths'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsConfigPaths()],
-  build: {
-    rollupOptions: {
-      external: ["trianglify"],
-      output: {
-        format: "esm",
-        globals: {
-          trianglify: "trianglify",
-        },
-      },
-    },
-  },
-
 })


### PR DESCRIPTION
I needed to update `src/trianglify.jsx` because Storybook started complaining that `trianglify` didn't have a `default` export. I tested the vite app and Storybook both in dev mode and after building so I think everything is still working xD.
It's a good idea to check that the lib still works when installed

<img width="939" alt="image" src="https://github.com/fdaciuk/react-trianglify/assets/46231311/d18076b6-4dde-44a8-9987-aa26c82a3fe6">
